### PR TITLE
add basic CUE definitions of Caddy config structure

### DIFF
--- a/definitions/caddy.cue
+++ b/definitions/caddy.cue
@@ -1,0 +1,24 @@
+package caddy
+
+Admin :: {
+	disabled:       bool | *false
+	listen:         string | *"localhost:2019"
+	enforce_origin: bool | *false
+	origins?: [...string]
+	config: {
+		persist: bool | *true
+	}
+}
+
+App :: {
+	http?: HTTPApp
+	pki?:  PKIApp
+	tls?:  TLSApp
+}
+
+Config :: {
+	admin:    Admin
+	logging?: Log
+	storage?: Storage
+	apps:     App
+}

--- a/definitions/caddy.cue
+++ b/definitions/caddy.cue
@@ -18,7 +18,7 @@ App :: {
 
 Config :: {
 	admin:    Admin
-	logging?: Log
+	logging:  Log
 	storage?: Storage
 	apps:     App
 }

--- a/definitions/http.cue
+++ b/definitions/http.cue
@@ -1,0 +1,341 @@
+package caddy
+
+Duration :: =~"^((\\d+)((n|u|m)?s|(m|h)))+$"
+
+// --- Handlers ---
+Authentication :: {
+	HTTPBasic :: {
+		BCrypt :: {
+			algorithm: "bcrypt"
+		}
+		Scrypt :: {
+			algorithm:  "scrypt"
+			N:          uint
+			r:          uint
+			p:          uint
+			key_length: uint
+		}
+		HashAlgorithm :: *BCrypt | Scrypt
+
+		hash: HashAlgorithm
+		accounts: [...{
+			username: string
+			password: string
+			salt:     string
+		}]
+		realm: string | *"restricted"
+	}
+
+	handler: "authentication"
+	providers: {
+		http_basic: HTTPBasic
+	}
+}
+Encode :: {
+	Encoder :: {
+		GzipEncoder :: {
+			level: uint | *0
+		}
+		ZstdEncoder :: {}
+		gzip?: GzipEncoder
+		zstd?: ZstdEncoder
+	}
+	handler:         "encode"
+	encodings:       Encoder
+	minimum_length?: uint
+}
+Error :: {
+	handler:     "error"
+	error?:      string
+	status_code: >=400 & <=600 | >=500
+}
+FileServer :: {
+	handler: "file_server"
+	root?:   string
+	hide?: [...string]
+	index_names?: [...string]
+	browse?: {
+		template_file?: string
+	}
+	canonical_uris?: bool
+	pass_thru:       bool | false
+}
+Headers :: {
+	HeaderReplace :: {
+		search?:        string
+		search_regexp?: string
+		replace?:       string
+	}
+
+	handler: "headers"
+	request?: {
+		add?: [string]: [...string]
+		set?: [string]: [...string]
+		delete?: [...string]
+		replace?: [string]: [...HeaderReplace]
+	}
+	response?: {
+		add?: [string]: [...string]
+		set?: [string]: [...string]
+		delete?: [...string]
+		replace?: [string]: [...HeaderReplace]
+		require?: {
+			status_code?: [...uint]
+			headers?: [string]: [...string]
+		}
+		deferred?: bool
+	}
+}
+RequestBody :: {
+	handler:   "request_body"
+	max_size?: uint
+}
+
+HTTPTransport :: {
+	protocol: "http"
+	tls?: {
+		root_ca_pool?: [...string]
+		root_ca_pem_files?: [...string]
+		client_certificate_file?:     string
+		client_certificate_key_file?: string
+		insecure_skip_verify?:        bool
+		handshake_timeout?:           uint | Duration
+		server_name:                  string
+	}
+	keep_alive?: {
+		enabled:                  bool
+		probe_interval:           uint
+		max_idle_conns?:          uint
+		max_idle_conns_per_host?: uint
+		idle_timeout?:            uint | Duration
+	}
+	compression?:              bool
+	max_conns_per_host?:       uint
+	dial_timeout?:             uint | Duration
+	dial_fallback_delay?:      uint
+	response_header_timeout?:  uint | Duration
+	expect_continue_timeout?:  uint | Duration
+	max_response_header_size?: uint
+	write_buffer_size?:        uint
+	read_buffer_size?:         uint
+	versions?: [...string]
+}
+FastCGITransport :: {
+	protocol: "fastcgi"
+	root:     string
+	split_path: [...string]
+	env: [string]: string
+	dial_timeout?:  uint | Duration
+	read_timeout?:  uint | Duration
+	write_timeout?: uint | Duration
+}
+Transport :: *HTTPTransport | FastCGITransport
+
+FirstSelectionPolicy :: {
+	policy: "first"
+}
+HeaderSelectionPolicy :: {
+	policy: "header"
+	field:  string
+}
+IPHashSelectionPolicy :: {
+	policy: "ip_hash"
+}
+LeastConnSelectionPolicy :: {
+	policy: "least_conn"
+}
+RandomSelectionPolicy :: {
+	policy: "random"
+}
+RandomChooseSelectionPolicy :: {
+	policy: "random_choose"
+	choose: uint
+}
+RoundRobinSelectinPolicy :: {
+	policy: "round_robin"
+}
+URIHashSelectionPolicy :: {
+	policy: "uri_hash"
+}
+SelectionPolicy :: FirstSelectionPolicy | HeaderSelectionPolicy | IPHashSelectionPolicy | LeastConnSelectionPolicy | *RandomSelectionPolicy | RandomChooseSelectionPolicy | RoundRobinSelectinPolicy | URIHashSelectionPolicy
+ReverseProxy :: {
+	handler:   "reverse_proxy"
+	transport: Transport
+	circuit_breaker?: {
+		type:       "internal"
+		threshold?: uint
+		factor:     *"latency" | "error_ratio" | "status_ratio"
+		trip_time:  string | Duration | *"5s"
+	}
+	load_balancing?: {
+		selection_policy?: SelectionPolicy
+		try_duration?:     uint | Duration
+		try_interval?:     uint | Duration
+		retry_match?: [...Matcher]
+	}
+	HealthCheck :: {
+		active?: {
+			path: string
+			port: uint
+			headers: [string]: [...string]
+			interval:      uint | Duration
+			timeout:       uint | Duration
+			max_size:      uint
+			expect_status: uint
+			expect_body:   string
+		}
+		passive?: {
+			fail_duration?:          uint | Duration
+			max_fails?:              uint
+			unhealthy_request_count: uint
+			unhealthy_status?: [...uint]
+			unhealthy_latency?: uint
+		}
+	}
+	health_checks?: HealthCheck
+	upstreams: [...{
+		dial:          string
+		lookup_srv?:   string
+		max_requests?: uint
+	}]
+	flush_interval?: uint | Duration
+	headers?:        Headers
+	buffer_requests: bool | *false
+}
+Rewrite :: {
+	handler:            "rewrite"
+	method?:            "GET" | "POST" | "HEAD" | "OPTIONS" | "DELETE" // TODO: other verbs
+	uri?:               string
+	strip_path_prefix?: string
+	strip_path_suffix?: string
+	uri_substring?: [...{
+		find:    string
+		replace: string
+		limit:   uint
+	}]
+}
+StaticResponse :: {
+	handler:      "static_response"
+	status_code?: string
+	body:         string
+	close?:       bool
+}
+Subroute :: {
+	handler: "subroute"
+	routes: [...Route]
+	errors?: {
+		routes: [...Route]
+	}
+}
+Templates :: {
+	handler:   "templates"
+	file_root: string
+	mime_types: [...string]
+	delimiters: [...string]
+}
+Vars :: {
+	handler:  "vars"
+	[string]: string
+}
+Handler :: Authentication | Encode | Error | FileServer | Headers | RequestBody | Rewrite | ReverseProxy | StaticResponse | Subroute | Templates | Vars
+
+// --- Matchers ---
+Expression :: string
+File :: {
+
+	root?: string
+	try_files?: [...string]
+	try_policy?: *"first_exist" | "smallest_size" | "largest_size" | "most_recently_modified"
+}
+Header :: [string]: [...string]
+
+HeaderRegexp :: [string]: [...{
+	name?:   string
+	pattern: string
+}]
+
+Host :: [...string]
+
+Method :: [...string] // TODO: Should it be limited to the list of possible HTTP verbs?
+
+Path :: [...string]
+
+PathRegexp :: {
+	name?:   string
+	pattern: string
+}
+
+Protocol :: string
+
+Query :: [string]: [...string]
+
+RemoteIP :: {
+	ranges: [...string]
+}
+
+VarsRegexp :: [string]: [...{
+	name?:   string
+	pattern: string
+}]
+Not :: {Matcher}
+Matcher :: {
+	exprssion?:     Expression
+	file?:          File
+	header?:        Header
+	header_regexp?: HeaderRegexp
+	host?:          Host
+	method?:        Method
+	path?:          Path
+	path_regexp?:   PathRegexp
+	protocol?:      Protocol
+	query?:         Query
+	remote_ip?:     RemoteIP
+	vars_regexp?:   VarsRegexp
+	not?:           Not
+}
+
+Route :: {
+	group?: string
+	match?: [...Matcher]
+	handle: [...Handler]
+	terminal?: bool
+}
+
+TLSWrapper :: {
+	"wrapper": "tls"
+}
+
+ListenerWrapper :: TLSWrapper
+
+HTTPServer :: {
+	listen: [...string]
+	listener_wrappers?: [...ListenerWrapper]
+	read_timeout?:     uint | Duration
+	write_timeout?:    uint | Duration
+	idle_timeout?:     uint | Duration
+	max_header_bytes?: uint
+	routes: [...Route]
+	errors?: {
+		routes: [...Route]
+	}
+	tls_connection_policies?: [...TLSConnectionPolicy]
+	automatic_https?: {
+		disable?:           bool
+		disable_redirects?: bool
+		skip?: [...string]
+		skip_certificates?: [...string]
+		ignore_loaded_certificates?: bool
+	}
+	strict_sni_host?: bool
+	logs?: {
+		logger_names: {[string]: string}
+	}
+	experimental_http3?: bool
+}
+
+HTTPApp :: {
+	http_port?:    uint
+	https_port?:   uint
+	grace_period?: uint | Duration
+	servers: {[string]: HTTPServer}
+}

--- a/definitions/log.cue
+++ b/definitions/log.cue
@@ -1,0 +1,75 @@
+package caddy
+
+FileWriter :: {
+	output:           "file"
+	filename:         string
+	roll?:            bool
+	roll_size_mb?:    uint
+	roll_gzip?:       bool
+	roll_local_time?: bool
+	roll_keep?:       uint
+	roll_keep_days?:  uint
+}
+NetWriter :: {
+	output:  "net"
+	address: string
+}
+StdxWriter :: {
+	output: *"stdout" | "stderr" | "discard"
+}
+LoggingWriter :: FileWriter | NetWriter | *StdxWriter
+
+DeleteFilterEncoder :: {
+	filter: "delete"
+}
+IPMaskFilterEncoder :: {
+	filter:     "ip_mask"
+	ipv4_cidr:  uint8
+	ipv6_cider: uint
+}
+FilterEncoderField :: DeleteFilterEncoder | IPMaskFilterEncoder
+
+keys: {
+	message_key?:     string
+	level_key?:       string
+	time_key?:        string
+	name_key?:        string
+	caller_key?:      string
+	stacktrace_key?:  string
+	line_ending?:     string
+	time_format?:     string
+	duration_format?: string
+	level_format?:    string
+}
+KeyedEncoder :: keys & {
+	format: "console" | *"json" | "logfmt"
+}
+FilterEncoder :: {
+	format: "filter"
+	wrap:   LoggingEncoder
+	fields: FilterEncoderField
+}
+SingleFieldEncoder :: {
+	format:   "single_field"
+	field:    string
+	fallback: LoggingEncoder
+}
+LoggingEncoder :: *KeyedEncoder | FilterEncoder | SingleFieldEncoder
+
+Log :: {
+	Logger :: {
+		writer:  LoggingWriter
+		encoder: LoggingEncoder
+		sampling?: {
+			interval?:   uint
+			first?:      uint
+			thereafter?: uint
+		}
+		include?: [...string]
+		exclude?: [...string]
+	}
+	sink?: {
+		writer: LoggingWriter
+	}
+	logs: [string]: Logger
+}

--- a/definitions/log.cue
+++ b/definitions/log.cue
@@ -29,7 +29,9 @@ IPMaskFilterEncoder :: {
 }
 FilterEncoderField :: DeleteFilterEncoder | IPMaskFilterEncoder
 
-keys: {
+KeyedEncoder :: {
+	format: "console" | *"json" | "logfmt"
+} & {
 	message_key?:     string
 	level_key?:       string
 	time_key?:        string
@@ -40,9 +42,6 @@ keys: {
 	time_format?:     string
 	duration_format?: string
 	level_format?:    string
-}
-KeyedEncoder :: keys & {
-	format: "console" | *"json" | "logfmt"
 }
 FilterEncoder :: {
 	format: "filter"
@@ -60,6 +59,7 @@ Log :: {
 	Logger :: {
 		writer:  LoggingWriter
 		encoder: LoggingEncoder
+		level: "DEBUG" | *"INFO" | "WARN" | "ERROR" | "PANIC" | "FATAL"
 		sampling?: {
 			interval?:   uint
 			first?:      uint
@@ -71,5 +71,21 @@ Log :: {
 	sink?: {
 		writer: LoggingWriter
 	}
-	logs: [string]: Logger
+	logMap :: [string]: Logger
+	logs: logMap & {
+		default: {
+			writer: {
+				output: "stderr"
+			}
+			encoder: {
+				format: "json"
+			}
+			level: "INFO"
+			sampling: {
+				interval: 1000000000 // 1 second
+				first: 100
+				thereafter: 100
+			}
+		}
+	}
 }

--- a/definitions/pki.cue
+++ b/definitions/pki.cue
@@ -1,0 +1,21 @@
+package caddy
+
+Cert :: {
+	certificate: string
+	private_key: string
+	format:      string
+}
+
+CertificateAuthority :: {
+	name:                     string
+	root_common_name:         string
+	intermediate_common_name: string
+	install_trust:            bool
+	root?:                    Cert
+	intermediate?:            Cert
+	storage:                  Storage
+}
+
+PKIApp :: {
+	"certificate_authorities": [string]: CertificateAuthority
+}

--- a/definitions/storage.cue
+++ b/definitions/storage.cue
@@ -1,0 +1,8 @@
+package caddy
+
+FilesystemStorage :: {
+	module: "filelsystem"
+	root?:  string
+}
+
+Storage :: FilesystemStorage

--- a/definitions/tls.cue
+++ b/definitions/tls.cue
@@ -1,0 +1,117 @@
+package caddy
+
+SerialNumber :: string
+
+TLSConnectionPolicy :: {
+	match?: {
+		sni?: [...string]
+	}
+	certificate_selection?: {
+		serial_number?: [...SerialNumber]
+		subject_organization?: [...string]
+		public_key_algorithm?: uint
+		any_tag?: [...string]
+		all_tags?: [...string]
+	}
+	cipher_suites?: [...string]
+	curves?: [...string]
+	alpn?: [...string]
+	protocol_min?: *"tls1.2" | "tls1.3"
+	protocol_max?: "tls1.2" | *"tls1.3"
+	client_authentication?: {
+		trusted_ca_certs?: [...string]
+		trusted_leaf_certs?: [...string]
+		mode?: "request" | "require" | "verify_if_given" | *"require_and_verify"
+	}
+	default_sni?: string
+}
+
+TLSApp :: {
+
+	automateCerts :: [...string] | *[""]
+	loadFiles :: [...{
+		certificate: string
+		key:         string
+		format:      string | *"pem"
+		tags: [...string]
+	}]
+	loadFolders :: [...string]
+	loadPEM :: [...{
+		certificate: string
+		key:         string
+		tags: [...string]
+	}]
+	certificates: {
+		automate:      automateCerts
+		load_files?:   loadFiles
+		load_folders?: loadFolders
+		load_pem?:     loadPEM
+	}
+	automation: {
+		internalIssuer :: {
+			module:         "internal"
+			ca:             string | "local"
+			lifetime:       Duration
+			sign_with_root: bool
+		}
+		acmeIssuer :: {
+			module:  "acme"
+			ca:      string
+			test_ca: string
+			email:   string
+			external_account?: {
+				key_id: string
+				hmac:   string
+			}
+			acme_timeout: Duration
+			challenges: {
+				http: {
+					disabled:       bool
+					alternate_port: uint
+				}
+				"tls-alpn": {
+					disabled:       bool
+					alternate_port: uint
+				}
+			}
+			trusted_roots_pem_files: [...string]
+		}
+		policies: [...{
+			subjects: [...string]
+			issuer: {
+
+			}
+			must_stable:          bool | *false
+			renewal_window_ratio: uint
+			key_type:             "ed25519" | "p256" | "p384" | "rsa2048" | "rsa4096"
+			storage:              Storage
+			on_demand:            bool
+		}]
+		on_demand: {
+			rate_limit: {
+				interval: uint
+				burst:    uint
+			}
+			ask: string
+		}
+		ocsp_interval:   Duration
+		renew_intervall: Duration
+	}
+
+	standardKeySource :: {
+		provider: "standard"
+	}
+	distributedKeySource :: {
+		provider: "distributed"
+		storage:  Storage
+	}
+	KeySource :: *standardKeySource | distributedKeySource
+
+	session_tickets: {
+		key_source:        KeySource
+		rotation_interval: Duration
+		max_keys:          uint | *4
+		disable_rotation:  bool | *false
+		disabled:          bool | *false
+	}
+}


### PR DESCRIPTION
Warning: I'm building this as I'm learning/exploring CUE. It is very likely it's not done with best practices. Review/guidance is very welcome and needed!

This seems to work... to a point. The two sample config files I'm using exhibit 2 behaviors:
1- One seems to work fine and filled with default values for missing fields
2- The other.... causes CUE to panic with stack overflow (I know the change that caused it to start panicking)

### Successful
Running `cue eval *.cue -d Config --out json caddy.json` against this config:
<details>
<pre>
{
	"apps": {
		"http": {
			"servers": {
				"srv0": {
					"listen": [
						":8080"
					],
					"routes": [
						{
							"match": [
								{
									"host": [
										"localhost"
									],
									"path": [
										"/my-path"
									]
								}
							],
							"handle": [
								{
									"handler": "static_response",
									"status_code": "200",
									"body": "Hello!"
								}
							]
						},
						{
							"handle": [
								{
									"handler": "reverse_proxy",
									"transport": {
										"protocol": "http"
									},
									"circuit_breaker": {
										"type": "internal"
									},
									"upstreams": [
										{
											"dial": "tcp/10.1.1.1:2020",
											"max_requests": 5
										},
										{
											"dial": "tcp/10.1.1.1:2121",
											"max_requests": 5
										}
									]
								}
							]
						}
					]
				},
				"srv1": {
					"listen": [
						":9090"
					],
					"routes": [
						{
							"handle": [
								{
									"handler": "static_response",
									"status_code": "200",
									"body": "Hello!"
								}
							]
						}
					]
				}
			}
		}
	}
}
</pre>
</details>
Results in this output (note the default values being filled in):
<details>
<pre>
{
    "admin": {
        "disabled": false,
        "listen": "localhost:2019",
        "enforce_origin": false,
        "config": {
            "persist": true
        }
    },
    "apps": {
        "http": {
            "servers": {
                "srv0": {
                    "listen": [
                        ":8080"
                    ],
                    "routes": [
                        {
                            "match": [
                                {
                                    "path": [
                                        "/my-path"
                                    ],
                                    "host": [
                                        "localhost"
                                    ]
                                }
                            ],
                            "handle": [
                                {
                                    "body": "Hello!",
                                    "handler": "static_response",
                                    "status_code": "200"
                                }
                            ]
                        },
                        {
                            "handle": [
                                {
                                    "handler": "reverse_proxy",
                                    "transport": {
                                        "protocol": "http"
                                    },
                                    "circuit_breaker": {
                                        "type": "internal",
                                        "factor": "latency",
                                        "trip_time": "5s"
                                    },
                                    "upstreams": [
                                        {
                                            "dial": "tcp/10.1.1.1:2020",
                                            "max_requests": 5
                                        },
                                        {
                                            "dial": "tcp/10.1.1.1:2121",
                                            "max_requests": 5
                                        }
                                    ],
                                    "buffer_requests": false
                                }
                            ]
                        }
                    ]
                },
                "srv1": {
                    "listen": [
                        ":9090"
                    ],
                    "routes": [
                        {
                            "handle": [
                                {
                                    "body": "Hello!",
                                    "handler": "static_response",
                                    "status_code": "200"
                                }
                            ]
                        }
                    ]
                }
            }
        }
    }
}
</pre>
</details>

### Failed

Running `cue eval *.cue -d Config --out json caddy.json` against this config:
<details>
<pre>
{
	"admin": {
		"disabled": false,
		"enforce_origin": false
	},
	"logging": {
		"logs": {
			"log0": {
				"writer": {
					"output": "discard"
				},
				"encoder": {
					"format": "json",
					"message_key": "some_key"
				}
			}
		}
	},
	"apps": {
		"http": {
			"servers": {
				"srv0": {
					"listen": [
						"80",
						"443"
					],
					"routes": [
						{
							"handle": [
								{
									"handler": "static_response",
									"status_code": "200",
									"body": "Hello!"
								}
							]
						}
					]
				},
				"srv1": {
					"listen": [
						"80",
						"443"
					],
					"routes": [
						{
							"handle": [
								{
									"handler": "static_response",
									"status_code": "200",
									"body": "Hello!"
								}
							]
						}
					]
				}
			}
		}
	}
}
</pre>
</details>

Results in this output:
<details>
<pre>
runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0xc020660440 stack=[0xc020660000, 0xc040660000]
fatal error: stack overflow

runtime stack:
runtime.throw(0x185450a, 0xe)
        /usr/local/go/src/runtime/panic.go:1114 +0x72
runtime.newstack()
        /usr/local/go/src/runtime/stack.go:1034 +0x6ce
runtime.morestack()
        /usr/local/go/src/runtime/asm_amd64.s:449 +0x8f

goroutine 1 [running]:
cuelang.org/go/cue.(*structLit).expandFields(0xc0003c4fc0, 0xc000593340, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/value.go:1115 +0x1055 fp=0xc020660450 sp=0xc020660448 pc=0x13d2df5
cuelang.org/go/cue.(*structLit).lookup(0xc0003c4fc0, 0xc000593340, 0x49e, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/value.go:999 +0x77 fp=0xc020660580 sp=0xc020660450 pc=0x13d1017
cuelang.org/go/cue.(*structLit).subsumesImpl(0xc0003df570, 0xc0112bda90, 0x1987680, 0xc0003c4fc0, 0xc0003c4fc0)
        /Users/mpvl/Documents/dev/release/cue/cue/subsume.go:209 +0x515 fp=0xc0206607f8 sp=0xc020660580 pc=0x13b7215
cuelang.org/go/cue.(*subsumer).subsumes(0xc0112bda90, 0x1987680, 0xc0003df570, 0x1987680, 0xc0003c4fc0, 0x13d6000)
        /Users/mpvl/Documents/dev/release/cue/cue/subsume.go:160 +0x26c fp=0xc020660898 sp=0xc0206607f8 pc=0x13b686c
cuelang.org/go/cue.(*disjunction).normalize.func1(0xc000593340, 0x1987680, 0xc0003c4fc0, 0x0, 0x1987680, 0xc0003df570, 0xc000593301, 0x1988700)
        /Users/mpvl/Documents/dev/release/cue/cue/value.go:1682 +0xc4 fp=0xc0206608e0 sp=0xc020660898 pc=0x13e8994
cuelang.org/go/cue.(*disjunction).normalize(0xc0003ea500, 0xc000593340, 0x197fca0, 0xc0003ea500, 0xc0003c50a0, 0xc020660a58, 0x13d1523)
        /Users/mpvl/Documents/dev/release/cue/cue/value.go:1709 +0x736 fp=0xc0206609c0 sp=0xc0206608e0 pc=0x13d60f6
cuelang.org/go/cue.(*disjunction).evalPartial(0xc0003ea500, 0xc000593340, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/eval.go:546 +0x3cd fp=0xc020660b10 sp=0xc0206609c0 pc=0x1391f5d
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1986fc0, 0xc0003ea500, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:408 +0x91 fp=0xc020661158 sp=0xc020660b10 pc=0x1399441
cuelang.org/go/cue.(*exporter).recExpr(0xc0000a42a0, 0x1987500, 0xc0003c1a70, 0x1989260, 0xc0003ea500, 0xc012ce0900, 0x0, 0x1)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:387 +0x294 fp=0xc0206611c8 sp=0xc020661158 pc=0x1398cc4
cuelang.org/go/cue.(*exporter).structure(0xc0000a42a0, 0xc0003c4fc0, 0xc0003c4f00, 0x1987680, 0xc0003c4fc0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:887 +0xffb fp=0xc020661440 sp=0xc0206611c8 pc=0x139fbdb
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1987680, 0xc0003c4fc0, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:587 +0x13f3 fp=0xc020661a88 sp=0xc020661440 pc=0x139a7a3
cuelang.org/go/cue.(*exporter).expr.func2(...)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:571
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1986fc0, 0xc0003ea500, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:579 +0x3257 fp=0xc0206620d0 sp=0xc020661a88 pc=0x139c607
cuelang.org/go/cue.(*exporter).recExpr(0xc0000a42a0, 0x1987500, 0xc0003c1a70, 0x1989260, 0xc0003ea500, 0xc012ce0900, 0x0, 0x1)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:387 +0x294 fp=0xc020662140 sp=0xc0206620d0 pc=0x1398cc4
cuelang.org/go/cue.(*exporter).structure(0xc0000a42a0, 0xc0003c4fc0, 0xc0003c4f00, 0x1987680, 0xc0003c4fc0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:887 +0xffb fp=0xc0206623b8 sp=0xc020662140 pc=0x139fbdb
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1987680, 0xc0003c4fc0, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:587 +0x13f3 fp=0xc020662a00 sp=0xc0206623b8 pc=0x139a7a3
cuelang.org/go/cue.(*exporter).expr.func2(...)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:571
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1986fc0, 0xc0003ea500, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:579 +0x3257 fp=0xc020663048 sp=0xc020662a00 pc=0x139c607
cuelang.org/go/cue.(*exporter).recExpr(0xc0000a42a0, 0x1987500, 0xc0003c1a70, 0x1989260, 0xc0003ea500, 0xc012ce0900, 0x0, 0x1)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:387 +0x294 fp=0xc0206630b8 sp=0xc020663048 pc=0x1398cc4
cuelang.org/go/cue.(*exporter).structure(0xc0000a42a0, 0xc0003c4fc0, 0xc0003c4f00, 0x1987680, 0xc0003c4fc0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:887 +0xffb fp=0xc020663330 sp=0xc0206630b8 pc=0x139fbdb
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1987680, 0xc0003c4fc0, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:587 +0x13f3 fp=0xc020663978 sp=0xc020663330 pc=0x139a7a3
cuelang.org/go/cue.(*exporter).expr.func2(...)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:571
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1986fc0, 0xc0003ea500, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:579 +0x3257 fp=0xc020663fc0 sp=0xc020663978 pc=0x139c607
cuelang.org/go/cue.(*exporter).recExpr(0xc0000a42a0, 0x1987500, 0xc0003c1a70, 0x1989260, 0xc0003ea500, 0xc012ce0900, 0x0, 0x1)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:387 +0x294 fp=0xc020664030 sp=0xc020663fc0 pc=0x1398cc4
cuelang.org/go/cue.(*exporter).structure(0xc0000a42a0, 0xc0003c4fc0, 0xc0003c4f00, 0x1987680, 0xc0003c4fc0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:887 +0xffb fp=0xc0206642a8 sp=0xc020664030 pc=0x139fbdb
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1987680, 0xc0003c4fc0, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:587 +0x13f3 fp=0xc0206648f0 sp=0xc0206642a8 pc=0x139a7a3
cuelang.org/go/cue.(*exporter).expr.func2(...)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:571
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1986fc0, 0xc0003ea500, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:579 +0x3257 fp=0xc020664f38 sp=0xc0206648f0 pc=0x139c607
cuelang.org/go/cue.(*exporter).recExpr(0xc0000a42a0, 0x1987500, 0xc0003c1a70, 0x1989260, 0xc0003ea500, 0xc012ce0900, 0x0, 0x1)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:387 +0x294 fp=0xc020664fa8 sp=0xc020664f38 pc=0x1398cc4
cuelang.org/go/cue.(*exporter).structure(0xc0000a42a0, 0xc0003c4fc0, 0xc0003c4f00, 0x1987680, 0xc0003c4fc0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:887 +0xffb fp=0xc020665220 sp=0xc020664fa8 pc=0x139fbdb
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1987680, 0xc0003c4fc0, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:587 +0x13f3 fp=0xc020665868 sp=0xc020665220 pc=0x139a7a3
cuelang.org/go/cue.(*exporter).expr.func2(...)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:571
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1986fc0, 0xc0003ea500, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:579 +0x3257 fp=0xc020665eb0 sp=0xc020665868 pc=0x139c607
cuelang.org/go/cue.(*exporter).recExpr(0xc0000a42a0, 0x1987500, 0xc0003c1a70, 0x1989260, 0xc0003ea500, 0xc012ce0900, 0x0, 0x1)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:387 +0x294 fp=0xc020665f20 sp=0xc020665eb0 pc=0x1398cc4
cuelang.org/go/cue.(*exporter).structure(0xc0000a42a0, 0xc0003c4fc0, 0xc0003c4f00, 0x1987680, 0xc0003c4fc0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:887 +0xffb fp=0xc020666198 sp=0xc020665f20 pc=0x139fbdb
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1987680, 0xc0003c4fc0, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:587 +0x13f3 fp=0xc0206667e0 sp=0xc020666198 pc=0x139a7a3
cuelang.org/go/cue.(*exporter).expr.func2(...)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:571
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1986fc0, 0xc0003ea500, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:579 +0x3257 fp=0xc020666e28 sp=0xc0206667e0 pc=0x139c607
cuelang.org/go/cue.(*exporter).recExpr(0xc0000a42a0, 0x1987500, 0xc0003c1a70, 0x1989260, 0xc0003ea500, 0xc012ce0800, 0x0, 0x1)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:387 +0x294 fp=0xc020666e98 sp=0xc020666e28 pc=0x1398cc4
cuelang.org/go/cue.(*exporter).structure(0xc0000a42a0, 0xc0003c4fc0, 0xc0003c4f00, 0x1987680, 0xc0003c4fc0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:887 +0xffb fp=0xc020667110 sp=0xc020666e98 pc=0x139fbdb
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1987680, 0xc0003c4fc0, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:587 +0x13f3 fp=0xc020667758 sp=0xc020667110 pc=0x139a7a3
cuelang.org/go/cue.(*exporter).expr.func2(...)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:571
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1986fc0, 0xc0003ea500, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:579 +0x3257 fp=0xc020667da0 sp=0xc020667758 pc=0x139c607
cuelang.org/go/cue.(*exporter).recExpr(0xc0000a42a0, 0x1987500, 0xc0003c1a70, 0x1989260, 0xc0003ea500, 0xc012ce0800, 0x0, 0x1)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:387 +0x294 fp=0xc020667e10 sp=0xc020667da0 pc=0x1398cc4
cuelang.org/go/cue.(*exporter).structure(0xc0000a42a0, 0xc0003c4fc0, 0xc0003c4f00, 0x1987680, 0xc0003c4fc0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:887 +0xffb fp=0xc020668088 sp=0xc020667e10 pc=0x139fbdb
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1987680, 0xc0003c4fc0, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:587 +0x13f3 fp=0xc0206686d0 sp=0xc020668088 pc=0x139a7a3
cuelang.org/go/cue.(*exporter).expr.func2(...)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:571
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1986fc0, 0xc0003ea500, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:579 +0x3257 fp=0xc020668d18 sp=0xc0206686d0 pc=0x139c607
cuelang.org/go/cue.(*exporter).recExpr(0xc0000a42a0, 0x1987500, 0xc0003c1a70, 0x1989260, 0xc0003ea500, 0xc012ce0800, 0x0, 0x1)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:387 +0x294 fp=0xc020668d88 sp=0xc020668d18 pc=0x1398cc4
cuelang.org/go/cue.(*exporter).structure(0xc0000a42a0, 0xc0003c4fc0, 0xc0003c4f00, 0x1987680, 0xc0003c4fc0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:887 +0xffb fp=0xc020669000 sp=0xc020668d88 pc=0x139fbdb
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1987680, 0xc0003c4fc0, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:587 +0x13f3 fp=0xc020669648 sp=0xc020669000 pc=0x139a7a3
cuelang.org/go/cue.(*exporter).expr.func2(...)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:571
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1986fc0, 0xc0003ea500, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:579 +0x3257 fp=0xc020669c90 sp=0xc020669648 pc=0x139c607
cuelang.org/go/cue.(*exporter).recExpr(0xc0000a42a0, 0x1987500, 0xc0003c1a70, 0x1989260, 0xc0003ea500, 0xc012ce0800, 0x0, 0x1)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:387 +0x294 fp=0xc020669d00 sp=0xc020669c90 pc=0x1398cc4
cuelang.org/go/cue.(*exporter).structure(0xc0000a42a0, 0xc0003c4fc0, 0xc0003c4f00, 0x1987680, 0xc0003c4fc0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:887 +0xffb fp=0xc020669f78 sp=0xc020669d00 pc=0x139fbdb
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1987680, 0xc0003c4fc0, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:587 +0x13f3 fp=0xc02066a5c0 sp=0xc020669f78 pc=0x139a7a3
cuelang.org/go/cue.(*exporter).expr.func2(...)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:571
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1986fc0, 0xc0003ea500, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:579 +0x3257 fp=0xc02066ac08 sp=0xc02066a5c0 pc=0x139c607
cuelang.org/go/cue.(*exporter).recExpr(0xc0000a42a0, 0x1987500, 0xc0003c1a70, 0x1989260, 0xc0003ea500, 0xc012ce0800, 0x0, 0x1)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:387 +0x294 fp=0xc02066ac78 sp=0xc02066ac08 pc=0x1398cc4
cuelang.org/go/cue.(*exporter).structure(0xc0000a42a0, 0xc0003c4fc0, 0xc0003c4f00, 0x1987680, 0xc0003c4fc0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:887 +0xffb fp=0xc02066aef0 sp=0xc02066ac78 pc=0x139fbdb
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1987680, 0xc0003c4fc0, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:587 +0x13f3 fp=0xc02066b538 sp=0xc02066aef0 pc=0x139a7a3
cuelang.org/go/cue.(*exporter).expr.func2(...)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:571
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1986fc0, 0xc0003ea500, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:579 +0x3257 fp=0xc02066bb80 sp=0xc02066b538 pc=0x139c607
cuelang.org/go/cue.(*exporter).recExpr(0xc0000a42a0, 0x1987500, 0xc0003c1a70, 0x1989260, 0xc0003ea500, 0xc012ce0800, 0x0, 0x1)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:387 +0x294 fp=0xc02066bbf0 sp=0xc02066bb80 pc=0x1398cc4
cuelang.org/go/cue.(*exporter).structure(0xc0000a42a0, 0xc0003c4fc0, 0xc0003c4f00, 0x1987680, 0xc0003c4fc0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:887 +0xffb fp=0xc02066be68 sp=0xc02066bbf0 pc=0x139fbdb
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1987680, 0xc0003c4fc0, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:587 +0x13f3 fp=0xc02066c4b0 sp=0xc02066be68 pc=0x139a7a3
cuelang.org/go/cue.(*exporter).expr.func2(...)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:571
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1986fc0, 0xc0003ea500, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:579 +0x3257 fp=0xc02066caf8 sp=0xc02066c4b0 pc=0x139c607
cuelang.org/go/cue.(*exporter).recExpr(0xc0000a42a0, 0x1987500, 0xc0003c1a70, 0x1989260, 0xc0003ea500, 0xc012ce0800, 0x0, 0x1)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:387 +0x294 fp=0xc02066cb68 sp=0xc02066caf8 pc=0x1398cc4
cuelang.org/go/cue.(*exporter).structure(0xc0000a42a0, 0xc0003c4fc0, 0xc0003c4f00, 0x1987680, 0xc0003c4fc0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:887 +0xffb fp=0xc02066cde0 sp=0xc02066cb68 pc=0x139fbdb
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1987680, 0xc0003c4fc0, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:587 +0x13f3 fp=0xc02066d428 sp=0xc02066cde0 pc=0x139a7a3
cuelang.org/go/cue.(*exporter).expr.func2(...)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:571
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1986fc0, 0xc0003ea500, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:579 +0x3257 fp=0xc02066da70 sp=0xc02066d428 pc=0x139c607
cuelang.org/go/cue.(*exporter).recExpr(0xc0000a42a0, 0x1987500, 0xc0003c1a70, 0x1989260, 0xc0003ea500, 0xc012ce0800, 0x0, 0x1)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:387 +0x294 fp=0xc02066dae0 sp=0xc02066da70 pc=0x1398cc4
cuelang.org/go/cue.(*exporter).structure(0xc0000a42a0, 0xc0003c4fc0, 0xc0003c4f00, 0x1987680, 0xc0003c4fc0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:887 +0xffb fp=0xc02066dd58 sp=0xc02066dae0 pc=0x139fbdb
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1987680, 0xc0003c4fc0, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:587 +0x13f3 fp=0xc02066e3a0 sp=0xc02066dd58 pc=0x139a7a3
cuelang.org/go/cue.(*exporter).expr.func2(...)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:571
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1986fc0, 0xc0003ea500, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:579 +0x3257 fp=0xc02066e9e8 sp=0xc02066e3a0 pc=0x139c607
cuelang.org/go/cue.(*exporter).recExpr(0xc0000a42a0, 0x1987500, 0xc0003c1a70, 0x1989260, 0xc0003ea500, 0xc012ce0700, 0x0, 0x1)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:387 +0x294 fp=0xc02066ea58 sp=0xc02066e9e8 pc=0x1398cc4
cuelang.org/go/cue.(*exporter).structure(0xc0000a42a0, 0xc0003c4fc0, 0xc0003c4f00, 0x1987680, 0xc0003c4fc0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:887 +0xffb fp=0xc02066ecd0 sp=0xc02066ea58 pc=0x139fbdb
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1987680, 0xc0003c4fc0, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:587 +0x13f3 fp=0xc02066f318 sp=0xc02066ecd0 pc=0x139a7a3
cuelang.org/go/cue.(*exporter).expr.func2(...)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:571
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1986fc0, 0xc0003ea500, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:579 +0x3257 fp=0xc02066f960 sp=0xc02066f318 pc=0x139c607
cuelang.org/go/cue.(*exporter).recExpr(0xc0000a42a0, 0x1987500, 0xc0003c1a70, 0x1989260, 0xc0003ea500, 0xc012ce0700, 0x0, 0x1)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:387 +0x294 fp=0xc02066f9d0 sp=0xc02066f960 pc=0x1398cc4
cuelang.org/go/cue.(*exporter).structure(0xc0000a42a0, 0xc0003c4fc0, 0xc0003c4f00, 0x1987680, 0xc0003c4fc0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:887 +0xffb fp=0xc02066fc48 sp=0xc02066f9d0 pc=0x139fbdb
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1987680, 0xc0003c4fc0, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:587 +0x13f3 fp=0xc020670290 sp=0xc02066fc48 pc=0x139a7a3
cuelang.org/go/cue.(*exporter).expr.func2(...)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:571
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1986fc0, 0xc0003ea500, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:579 +0x3257 fp=0xc0206708d8 sp=0xc020670290 pc=0x139c607
cuelang.org/go/cue.(*exporter).recExpr(0xc0000a42a0, 0x1987500, 0xc0003c1a70, 0x1989260, 0xc0003ea500, 0xc012ce0700, 0x0, 0x1)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:387 +0x294 fp=0xc020670948 sp=0xc0206708d8 pc=0x1398cc4
cuelang.org/go/cue.(*exporter).structure(0xc0000a42a0, 0xc0003c4fc0, 0xc0003c4f00, 0x1987680, 0xc0003c4fc0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:887 +0xffb fp=0xc020670bc0 sp=0xc020670948 pc=0x139fbdb
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1987680, 0xc0003c4fc0, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:587 +0x13f3 fp=0xc020671208 sp=0xc020670bc0 pc=0x139a7a3
cuelang.org/go/cue.(*exporter).expr.func2(...)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:571
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1986fc0, 0xc0003ea500, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:579 +0x3257 fp=0xc020671850 sp=0xc020671208 pc=0x139c607
cuelang.org/go/cue.(*exporter).recExpr(0xc0000a42a0, 0x1987500, 0xc0003c1a70, 0x1989260, 0xc0003ea500, 0xc012ce0700, 0x0, 0x1)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:387 +0x294 fp=0xc0206718c0 sp=0xc020671850 pc=0x1398cc4
cuelang.org/go/cue.(*exporter).structure(0xc0000a42a0, 0xc0003c4fc0, 0xc0003c4f00, 0x1987680, 0xc0003c4fc0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:887 +0xffb fp=0xc020671b38 sp=0xc0206718c0 pc=0x139fbdb
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1987680, 0xc0003c4fc0, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:587 +0x13f3 fp=0xc020672180 sp=0xc020671b38 pc=0x139a7a3
cuelang.org/go/cue.(*exporter).expr.func2(...)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:571
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1986fc0, 0xc0003ea500, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:579 +0x3257 fp=0xc0206727c8 sp=0xc020672180 pc=0x139c607
cuelang.org/go/cue.(*exporter).recExpr(0xc0000a42a0, 0x1987500, 0xc0003c1a70, 0x1989260, 0xc0003ea500, 0xc012ce0700, 0x0, 0x1)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:387 +0x294 fp=0xc020672838 sp=0xc0206727c8 pc=0x1398cc4
cuelang.org/go/cue.(*exporter).structure(0xc0000a42a0, 0xc0003c4fc0, 0xc0003c4f00, 0x1987680, 0xc0003c4fc0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:887 +0xffb fp=0xc020672ab0 sp=0xc020672838 pc=0x139fbdb
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1987680, 0xc0003c4fc0, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:587 +0x13f3 fp=0xc0206730f8 sp=0xc020672ab0 pc=0x139a7a3
cuelang.org/go/cue.(*exporter).expr.func2(...)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:571
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1986fc0, 0xc0003ea500, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:579 +0x3257 fp=0xc020673740 sp=0xc0206730f8 pc=0x139c607
cuelang.org/go/cue.(*exporter).recExpr(0xc0000a42a0, 0x1987500, 0xc0003c1a70, 0x1989260, 0xc0003ea500, 0xc012ce0700, 0x0, 0x1)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:387 +0x294 fp=0xc0206737b0 sp=0xc020673740 pc=0x1398cc4
cuelang.org/go/cue.(*exporter).structure(0xc0000a42a0, 0xc0003c4fc0, 0xc0003c4f00, 0x1987680, 0xc0003c4fc0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:887 +0xffb fp=0xc020673a28 sp=0xc0206737b0 pc=0x139fbdb
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1987680, 0xc0003c4fc0, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:587 +0x13f3 fp=0xc020674070 sp=0xc020673a28 pc=0x139a7a3
cuelang.org/go/cue.(*exporter).expr.func2(...)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:571
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1986fc0, 0xc0003ea500, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:579 +0x3257 fp=0xc0206746b8 sp=0xc020674070 pc=0x139c607
cuelang.org/go/cue.(*exporter).recExpr(0xc0000a42a0, 0x1987500, 0xc0003c1a70, 0x1989260, 0xc0003ea500, 0xc012ce0700, 0x0, 0x1)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:387 +0x294 fp=0xc020674728 sp=0xc0206746b8 pc=0x1398cc4
cuelang.org/go/cue.(*exporter).structure(0xc0000a42a0, 0xc0003c4fc0, 0xc0003c4f00, 0x1987680, 0xc0003c4fc0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:887 +0xffb fp=0xc0206749a0 sp=0xc020674728 pc=0x139fbdb
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1987680, 0xc0003c4fc0, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:587 +0x13f3 fp=0xc020674fe8 sp=0xc0206749a0 pc=0x139a7a3
cuelang.org/go/cue.(*exporter).expr.func2(...)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:571
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1986fc0, 0xc0003ea500, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:579 +0x3257 fp=0xc020675630 sp=0xc020674fe8 pc=0x139c607
cuelang.org/go/cue.(*exporter).recExpr(0xc0000a42a0, 0x1987500, 0xc0003c1a70, 0x1989260, 0xc0003ea500, 0xc012ce0700, 0x0, 0x1)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:387 +0x294 fp=0xc0206756a0 sp=0xc020675630 pc=0x1398cc4
cuelang.org/go/cue.(*exporter).structure(0xc0000a42a0, 0xc0003c4fc0, 0xc0003c4f00, 0x1987680, 0xc0003c4fc0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:887 +0xffb fp=0xc020675918 sp=0xc0206756a0 pc=0x139fbdb
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1987680, 0xc0003c4fc0, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:587 +0x13f3 fp=0xc020675f60 sp=0xc020675918 pc=0x139a7a3
cuelang.org/go/cue.(*exporter).expr.func2(...)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:571
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1986fc0, 0xc0003ea500, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:579 +0x3257 fp=0xc0206765a8 sp=0xc020675f60 pc=0x139c607
cuelang.org/go/cue.(*exporter).recExpr(0xc0000a42a0, 0x1987500, 0xc0003c1a70, 0x1989260, 0xc0003ea500, 0xc012ce0600, 0x0, 0x1)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:387 +0x294 fp=0xc020676618 sp=0xc0206765a8 pc=0x1398cc4
cuelang.org/go/cue.(*exporter).structure(0xc0000a42a0, 0xc0003c4fc0, 0xc0003c4f00, 0x1987680, 0xc0003c4fc0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:887 +0xffb fp=0xc020676890 sp=0xc020676618 pc=0x139fbdb
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1987680, 0xc0003c4fc0, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:587 +0x13f3 fp=0xc020676ed8 sp=0xc020676890 pc=0x139a7a3
cuelang.org/go/cue.(*exporter).expr.func2(...)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:571
cuelang.org/go/cue.(*exporter).expr(0xc0000a42a0, 0x1986fc0, 0xc0003ea500, 0x0, 0x0)
        /Users/mpvl/Documents/dev/release/cue/cue/export.go:579 +0x3257 fp=0xc020677520 sp=0xc020676ed8 pc=0x139c607
</pre>
</details>

Removing the default indicator `*` from `*"json"` and `*KeyedEncoder` in `log.cue` resolves the stack overflow.